### PR TITLE
Add modal for new request in client profile

### DIFF
--- a/Program/profile-client.html
+++ b/Program/profile-client.html
@@ -32,15 +32,17 @@
   </nav>
   <section class="profile-section" id="orders" style="display:none;">
     <button id="new-request-btn" class="btn" style="margin-bottom:10px;">Подать заявку</button>
-    <form id="new-request-form" style="display:none; margin-bottom:20px;">
-      <label for="work-type">Тип работ:</label>
-      <select id="work-type">
-        <option>Экологический аудит</option>
-        <option>Водный аудит</option>
-        <option>Выбросы в атмосферу</option>
-      </select>
-      <button type="submit" class="btn">Отправить</button>
-    </form>
+    <div id="request-overlay" class="overlay">
+      <form id="new-request-form" class="modal-form" style="margin-bottom:20px;">
+        <label for="work-type">Тип работ:</label>
+        <select id="work-type">
+          <option>Экологический аудит</option>
+          <option>Водный аудит</option>
+          <option>Выбросы в атмосферу</option>
+        </select>
+        <button type="submit" class="btn">Отправить</button>
+      </form>
+    </div>
     <div class="table-container">
     <table class="orders-table">
       <thead>
@@ -116,11 +118,15 @@ menuButtons.forEach(btn => {
 // показать первый раздел по умолчанию
 document.querySelector('.profile-menu button.active').click();
 
-// показать форму новой заявки
+// показать форму новой заявки в затемненном окне
 const newBtn = document.getElementById('new-request-btn');
-const form = document.getElementById('new-request-form');
+const overlay = document.getElementById('request-overlay');
 newBtn.addEventListener('click', () => {
-  form.style.display = form.style.display === 'block' ? 'none' : 'block';
+  overlay.style.display = 'flex';
+});
+
+overlay.addEventListener('click', (e) => {
+  if (e.target === overlay) overlay.style.display = 'none';
 });
 // ограничение длины сообщений обрабатывается атрибутом maxlength
 </script>

--- a/Program/style.css
+++ b/Program/style.css
@@ -277,3 +277,24 @@
   background: #08641f;
   border-radius: 10px;
 }
+
+/* overlay styles for new request form */
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: none;
+  justify-content: center;
+  align-items: center;
+  z-index: 999;
+}
+
+.modal-form {
+  background: #fff;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+}


### PR DESCRIPTION
## Summary
- show the new request form as a modal overlay

## Testing
- `npx stylelint '**/*.css'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c5f88cec832fbaa71fb14086d5b3