### PR TITLE
Implement DB-based user auth

### DIFF
--- a/Program/auth.html
+++ b/Program/auth.html
@@ -35,7 +35,7 @@
         <button id="registerToggle">Регистрация</button>
       </div>
       <!-- Форма авторизации -->
-      <form id="loginForm" class="active" novalidate>
+      <form id="loginForm" class="active" method="post" action="../public/index.php?action=login" novalidate>
         <div class="form-group">
           <label for="loginEmail">Email</label>
           <input type="email" id="loginEmail" name="email" required placeholder="example@mail.ru">
@@ -47,7 +47,7 @@
         <button type="submit" class="btn-submit">Войти</button>
       </form>
       <!-- Форма регистрации -->
-      <form id="registerForm" novalidate>
+      <form id="registerForm" method="post" action="../public/index.php?action=register" novalidate>
         <div class="form-group">
           <label for="regType">Тип пользователя</label>
           <select id="regType" name="userType" required>
@@ -119,13 +119,7 @@
       }
     });
 
-    // Простая переадресация для демонстрации входа сотрудника
-    loginForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      window.location.href = 'profile-employee.html';
-    });
-
-    // TODO: добавить обработку отправки форм (AJAX) согласно условиям ВКР
+    // Простая обработка выбора типа пользователя
   </script>
 </body>
 </html>

--- a/app/controllers/AuthController.php
+++ b/app/controllers/AuthController.php
@@ -1,0 +1,39 @@
+<?php
+require_once __DIR__ . '/../models/ClientModel.php';
+
+class AuthController {
+    public static function register() {
+        $name = trim($_POST['fio'] ?? '');
+        $company = trim($_POST['companyName'] ?? '');
+        $email = trim($_POST['email'] ?? '');
+        $phone = trim($_POST['phone'] ?? '');
+        $password = $_POST['password'] ?? '';
+
+        if ($email === '' || $password === '') {
+            header('Location: ../Program/auth.html?error=invalid');
+            exit;
+        }
+        try {
+            ClientModel::createClient($name, $company, $email, $phone, $password);
+            header('Location: ../Program/auth.html?registered=1');
+        } catch (Exception $e) {
+            header('Location: ../Program/auth.html?error=exists');
+        }
+        exit;
+    }
+
+    public static function login() {
+        $email = trim($_POST['email'] ?? '');
+        $password = $_POST['password'] ?? '';
+        $clientId = ClientModel::authenticate($email, $password);
+        if ($clientId) {
+            session_start();
+            $_SESSION['client_id'] = $clientId;
+            header('Location: profile-client.html');
+        } else {
+            header('Location: ../Program/auth.html?error=invalid');
+        }
+        exit;
+    }
+}
+?>

--- a/app/models/ClientModel.php
+++ b/app/models/ClientModel.php
@@ -1,0 +1,40 @@
+<?php
+class ClientModel {
+    protected static function getDB() {
+        static $db = null;
+        if ($db === null) {
+            $dsn = getenv('DB_DSN') ?: 'pgsql:host=localhost;port=5432;dbname=NatureSecur;charset=utf8';
+            $user = getenv('DB_USER') ?: 'postgres';
+            $pass = getenv('DB_PASS') ?: 'ristal2222';
+            $db = new PDO($dsn, $user, $pass);
+            $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        }
+        return $db;
+    }
+
+    public static function createClient($name, $companyName, $email, $phone, $password) {
+        $db = self::getDB();
+        $stmt = $db->prepare("INSERT INTO clients (name, company_name, email, phone, password) VALUES (:name, :company, :email, :phone, :password)");
+        $hashed = password_hash($password, PASSWORD_BCRYPT);
+        $stmt->bindParam(':name', $name);
+        $stmt->bindParam(':company', $companyName);
+        $stmt->bindParam(':email', $email);
+        $stmt->bindParam(':phone', $phone);
+        $stmt->bindParam(':password', $hashed);
+        $stmt->execute();
+        return $db->lastInsertId();
+    }
+
+    public static function authenticate($email, $password) {
+        $db = self::getDB();
+        $stmt = $db->prepare("SELECT client_id, password FROM clients WHERE email = :email");
+        $stmt->bindParam(':email', $email);
+        $stmt->execute();
+        $client = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($client && password_verify($password, $client['password'])) {
+            return $client['client_id'];
+        }
+        return false;
+    }
+}
+?>

--- a/public/index.php
+++ b/public/index.php
@@ -2,6 +2,14 @@
 $action = $_GET['action'] ?? null;
 
 switch ($action) {
+    case 'register':
+        require_once __DIR__ . '/../app/controllers/AuthController.php';
+        AuthController::register();
+        break;
+    case 'login':
+        require_once __DIR__ . '/../app/controllers/AuthController.php';
+        AuthController::login();
+        break;
     case 'create_request':
         require_once __DIR__ . '/../app/controllers/RequestController.php';
         RequestController::create();


### PR DESCRIPTION
## Summary
- create `ClientModel` and `AuthController`
- handle registration and login actions in `public/index.php`
- update `Program/auth.html` forms to post to backend

## Testing
- `php -l app/controllers/AuthController.php`
- `php -l app/models/ClientModel.php`
- `php -l public/index.php`
- `php -l Program/auth.html`


------
https://chatgpt.com/codex/tasks/task_e_68583a1c2d68832f9b6a322e4a7f6a74