### PR TITLE
Implement dynamic client profile

### DIFF
--- a/app/controllers/AuthController.php
+++ b/app/controllers/AuthController.php
@@ -29,7 +29,7 @@ class AuthController {
         if ($clientId) {
             session_start();
             $_SESSION['client_id'] = $clientId;
-            header('Location: profile-client.html');
+            header('Location: profile-client.php');
         } else {
             header('Location: ../Program/auth.html?error=invalid');
         }

--- a/app/controllers/RequestController.php
+++ b/app/controllers/RequestController.php
@@ -8,20 +8,20 @@ class RequestController
         session_start();
 
         if (!isset($_SESSION['client_id'])) {
-            header('Location: profile-client.html?error=auth');
+            header('Location: profile-client.php?error=auth');
             exit;
         }
 
         $clientId = $_SESSION['client_id'];
         $orderType = trim($_POST['work_type'] ?? '');
         if ($orderType === '') {
-            header('Location: profile-client.html?error=invalid');
+            header('Location: profile-client.php?error=invalid');
             exit;
         }
 
         RequestModel::createRequest($clientId, $orderType);
 
-        header('Location: profile-client.html?success=1');
+        header('Location: profile-client.php?success=1');
         exit;
     }
 }

--- a/app/models/ClientModel.php
+++ b/app/models/ClientModel.php
@@ -38,5 +38,13 @@ class ClientModel {
         }
         return false;
     }
+
+    public static function getClientById($id) {
+        $db = self::getDB();
+        $stmt = $db->prepare("SELECT name, company_name, email, phone FROM clients WHERE client_id = :id");
+        $stmt->bindParam(':id', $id, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
 }
 ?>

--- a/app/models/OrderModel.php
+++ b/app/models/OrderModel.php
@@ -1,0 +1,28 @@
+<?php
+class OrderModel {
+    protected static function getDB() {
+        static $db = null;
+        if ($db === null) {
+            $dsn = getenv('DB_DSN') ?: 'pgsql:host=localhost;port=5432;dbname=NatureSecur';
+            $user = getenv('DB_USER') ?: 'postgres';
+            $pass = getenv('DB_PASS') ?: 'ristal2222';
+            $db = new PDO($dsn, $user, $pass);
+            $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        }
+        return $db;
+    }
+
+    public static function getOrdersByClient($clientId) {
+        $db = self::getDB();
+        $sql = "SELECT o.order_id, o.order_type, o.status,
+                       (SELECT file_path FROM reports r WHERE r.order_id = o.order_id ORDER BY version DESC LIMIT 1) AS file_path
+                FROM orders o
+                WHERE o.client_id = :client_id
+                ORDER BY o.order_id";
+        $stmt = $db->prepare($sql);
+        $stmt->bindParam(':client_id', $clientId, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+}
+?>

--- a/public/profile-client.php
+++ b/public/profile-client.php
@@ -1,3 +1,16 @@
+<?php
+session_start();
+if (!isset($_SESSION['client_id'])) {
+    header('Location: ../Program/auth.html');
+    exit;
+}
+require_once __DIR__ . '/../app/models/ClientModel.php';
+require_once __DIR__ . '/../app/models/OrderModel.php';
+
+$client = ClientModel::getClientById($_SESSION['client_id']);
+$orders = OrderModel::getOrdersByClient($_SESSION['client_id']);
+$displayName = $client['name'] ?: $client['company_name'];
+?>
 <!DOCTYPE html>
 <html lang="ru">
 <head>
@@ -9,7 +22,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Личный кабинет клиента</title>
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="../Program/style.css">
 </head>
 <body>
 <header>
@@ -27,7 +40,7 @@
 </header>
 <main class="profile-container">
   <div class="profile-heading">
-    <h1>Личный кабинет клиента <br> Добро пожаловать, <span id="client-name"> Иван Иванов</span></h1>
+    <h1>Личный кабинет клиента <br> Добро пожаловать, <span id="client-name"><?php echo htmlspecialchars($displayName); ?></span></h1>
     <button id="notifications-btn" class="notify-btn"><img src="bell.svg" alt="Уведомления"></button>
   </div>
   <nav class="profile-menu">
@@ -60,47 +73,46 @@
         </tr>
       </thead>
       <tbody>
+      <?php if ($orders): ?>
+        <?php foreach ($orders as $order): ?>
         <tr class="order-row">
-          <td>5001</td>
-          <td>Водный аудит</td>
-          <td>В работе</td>
-          <td>—</td>
+          <td><?php echo htmlspecialchars($order['order_id']); ?></td>
+          <td><?php echo htmlspecialchars($order['order_type']); ?></td>
+          <td><?php echo htmlspecialchars($order['status']); ?></td>
+          <td>
+            <?php if (!empty($order['file_path'])): ?>
+              <a href="<?php echo htmlspecialchars($order['file_path']); ?>" class="btn">Скачать</a>
+            <?php else: ?>
+              &mdash;
+            <?php endif; ?>
+          </td>
           <td>
             <button class="btn chat-toggle">Чат</button>
-            <div class="chat-area">
-              <div class="messages">
-                <p><strong>Сотрудник:</strong> Работа в процессе.</p>
-              </div>
+            <div class="chat-area" style="display:none;">
+              <div class="messages"></div>
               <textarea maxlength="500" placeholder="Введите сообщение"></textarea>
               <button class="btn send-message">Отправить</button>
             </div>
           </td>
         </tr>
-        <tr class="order-row">
-          <td>5002</td>
-          <td>Выбросы в атмосферу</td>
-          <td>Завершен</td>
-          <td><a href="#" class="btn">Скачать</a></td>
-          <td>
-            <button class="btn chat-toggle">Чат</button>
-            <div class="chat-area">
-              <div class="messages">
-                <p><strong>Сотрудник:</strong> Отчет доступен для скачивания.</p>
-              </div>
-              <textarea maxlength="500" placeholder="Введите сообщение"></textarea>
-              <button class="btn send-message">Отправить</button>
-            </div>
-          </td>
-        </tr>
+        <?php endforeach; ?>
+      <?php else: ?>
+        <tr><td colspan="5">Заказов нет</td></tr>
+      <?php endif; ?>
       </tbody>
     </table>
     </div>
   </section>
   <section class="profile-section" id="personal" style="display:none;">
     <h2>Личные данные</h2>
-    <p><strong>ФИО:</strong> Иван Петров</p>
-    <p><strong>Email:</strong> ivan.petrov@example.com</p>
-    <p><strong>Телефон:</strong> +7 987 654-32-10</p>
+    <?php if (!empty($client['name'])): ?>
+      <p><strong>ФИО:</strong> <?php echo htmlspecialchars($client['name']); ?></p>
+    <?php endif; ?>
+    <?php if (!empty($client['company_name'])): ?>
+      <p><strong>Организация:</strong> <?php echo htmlspecialchars($client['company_name']); ?></p>
+    <?php endif; ?>
+    <p><strong>Email:</strong> <?php echo htmlspecialchars($client['email']); ?></p>
+    <p><strong>Телефон:</strong> <?php echo htmlspecialchars($client['phone']); ?></p>
   </section>
   <div id="notifications-overlay" class="overlay">
     <div class="modal-form">


### PR DESCRIPTION
## Summary
- show real client data and orders in profile
- fetch profile info and orders from DB via new model
- redirect controllers to PHP profile
- convert public profile page to PHP with dynamic fields

## Testing
- `php` commands were not available, so no syntax check run

------
https://chatgpt.com/codex/tasks/task_e_685846d64a74832f86ae20e9c310d320