### PR TITLE
Add comment email on request decline

### DIFF
--- a/app/controllers/RequestController.php
+++ b/app/controllers/RequestController.php
@@ -49,8 +49,13 @@ class RequestController
         $client = ClientModel::getClientById($req['client_id']);
         if ($client && !empty($client['email'])) {
             $subject = 'Заявка отклонена';
-            $message = 'Ваша заявка №' . $requestId . ' отклонена. Причина: ' . $reason;
-            @mail($client['email'], $subject, $message);
+            $message = 'Ваша заявка №' . $requestId . " отклонена.\nПричина: " . $reason;
+            $encodedSubject = '=?UTF-8?B?' . base64_encode($subject) . '?=';
+            $headers = [
+                'From: no-reply@naturesecur.local',
+                'Content-Type: text/plain; charset=UTF-8'
+            ];
+            @mail($client['email'], $encodedSubject, $message, implode("\r\n", $headers));
         }
 
         RequestModel::deleteRequest($requestId);


### PR DESCRIPTION
## Summary
- enhance declined request emails with UTF-8 headers and reason text

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d2a90738832fb9693169a31d11a5