### PR TITLE
Add ability for employees to create orders manually

### DIFF
--- a/app/controllers/OrderController.php
+++ b/app/controllers/OrderController.php
@@ -1,0 +1,37 @@
+<?php
+require_once __DIR__ . '/../models/OrderModel.php';
+require_once __DIR__ . '/../models/ClientModel.php';
+
+class OrderController
+{
+    public static function create()
+    {
+        session_start();
+        if (!isset($_SESSION['emp_id'])) {
+            header('Location: ../Program/auth.html');
+            exit;
+        }
+
+        $clientId = intval($_POST['client_id'] ?? 0);
+        $orderType = trim($_POST['order_type'] ?? '');
+        $deadline = trim($_POST['deadline'] ?? '');
+        if ($clientId <= 0 || $orderType === '') {
+            header('Location: profile-employee.php?error=invalid');
+            exit;
+        }
+
+        $dl = $deadline !== '' ? $deadline : null;
+        $orderId = OrderModel::createOrder($clientId, $_SESSION['emp_id'], $orderType, $dl);
+
+        $client = ClientModel::getClientById($clientId);
+        if ($client && !empty($client['email'])) {
+            $subject = 'Создан новый заказ';
+            $message = 'Для вас создан заказ №' . $orderId . '.';
+            @mail($client['email'], $subject, $message);
+        }
+
+        header('Location: profile-employee.php?success=created');
+        exit;
+    }
+}
+?>

--- a/app/models/ClientModel.php
+++ b/app/models/ClientModel.php
@@ -46,5 +46,11 @@ class ClientModel {
         $stmt->execute();
         return $stmt->fetch(PDO::FETCH_ASSOC);
     }
+
+    public static function getAllClients() {
+        $db = self::getDB();
+        $stmt = $db->query("SELECT client_id, COALESCE(NULLIF(company_name, ''), name) AS display_name FROM clients ORDER BY display_name");
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
 }
 ?>

--- a/public/index.php
+++ b/public/index.php
@@ -22,6 +22,10 @@ switch ($action) {
         require_once __DIR__ . '/../app/controllers/RequestController.php';
         RequestController::createOrder();
         break;
+    case 'new_order':
+        require_once __DIR__ . '/../app/controllers/OrderController.php';
+        OrderController::create();
+        break;
     default:
         header('Location: ../Program/index.php');
         break;

--- a/public/profile-employee.php
+++ b/public/profile-employee.php
@@ -7,10 +7,12 @@ if (!isset($_SESSION['emp_id'])) {
 require_once __DIR__ . '/../app/models/EmployeeModel.php';
 require_once __DIR__ . '/../app/models/RequestModel.php';
 require_once __DIR__ . '/../app/models/OrderModel.php';
+require_once __DIR__ . '/../app/models/ClientModel.php';
 
 $employee = EmployeeModel::getEmployeeById($_SESSION['emp_id']);
 $requests = RequestModel::getAllRequests();
 $orders = OrderModel::getOrdersByEmployee($_SESSION['emp_id']);
+$clients = ClientModel::getAllClients();
 $displayName = trim($employee['first_name'] . ' ' . $employee['second_name']);
 ?>
 <!DOCTYPE html>
@@ -107,8 +109,31 @@ $displayName = trim($employee['first_name'] . ' ' . $employee['second_name']);
     </div>
   </section>
 
-  <section class="profile-section" id="orders" style="display:none;">
+<section class="profile-section" id="orders" style="display:none;">
     <h2>Заказы</h2>
+    <button id="new-order-btn" class="btn" style="margin-bottom:10px;">Новый заказ</button>
+    <div id="new-order-overlay" class="overlay">
+      <form id="new-order-form" class="modal-form" action="index.php?action=new_order" method="post">
+        <label for="new-client">Клиент:</label>
+        <select id="new-client" name="client_id" required>
+          <option value="" disabled selected>Выберите клиента</option>
+          <?php foreach ($clients as $cl): ?>
+            <option value="<?php echo $cl['client_id']; ?>"><?php echo htmlspecialchars($cl['display_name']); ?></option>
+          <?php endforeach; ?>
+        </select>
+        <label for="new-order-type">Тип работ:</label>
+        <select id="new-order-type" name="order_type" required>
+          <option>Экологический аудит</option>
+          <option>Водный аудит</option>
+          <option>Выбросы в атмосферу</option>
+        </select>
+        <p><strong>Сотрудник:</strong> <?php echo htmlspecialchars($displayName); ?></p><br>
+        <p><strong>Дата создания:</strong> <span id="new-order-date"></span></p><br>
+        <label for="new-deadline">Дедлайн:</label>
+        <input type="date" id="new-deadline" name="deadline" required>
+        <button type="submit" class="btn">Создать заказ</button>
+      </form>
+    </div>
     <div class="table-container">
     <table class="orders-table">
       <thead>
@@ -257,6 +282,18 @@ createButtons.forEach(btn => {
 });
 createOverlay.addEventListener('click', (e) => {
   if (e.target === createOverlay) createOverlay.style.display = 'none';
+});
+
+// создание нового заказа
+const newOrderBtn = document.getElementById('new-order-btn');
+const newOrderOverlay = document.getElementById('new-order-overlay');
+const newOrderDate = document.getElementById('new-order-date');
+newOrderBtn.addEventListener('click', () => {
+  newOrderDate.textContent = new Date().toISOString().slice(0, 10);
+  newOrderOverlay.style.display = 'flex';
+});
+newOrderOverlay.addEventListener('click', (e) => {
+  if (e.target === newOrderOverlay) newOrderOverlay.style.display = 'none';
 });
 
 // сообщения об операциях


### PR DESCRIPTION
## Summary
- add `ClientModel::getAllClients` helper
- implement `OrderController` with create action
- route `new_order` action
- extend employee profile with `Новый заказ` overlay and script

## Testing
- `php -l app/models/ClientModel.php`
- `php -l app/controllers/OrderController.php`
- `php -l app/controllers/RequestController.php`
- `php -l public/profile-employee.php`
- `php -l public/index.php`

------
https://chatgpt.com/codex/tasks/task_e_6859dd2dfacc832faf0a8e6faea319f2