### PR TITLE
Fix order status update

### DIFF
--- a/app/controllers/OrderController.php
+++ b/app/controllers/OrderController.php
@@ -33,5 +33,26 @@ class OrderController
         header('Location: profile-employee.php?success=created');
         exit;
     }
+
+    public static function updateStatus()
+    {
+        session_start();
+        if (!isset($_SESSION['emp_id'])) {
+            header('Location: ../Program/auth.html');
+            exit;
+        }
+
+        $orderId = intval($_POST['order_id'] ?? 0);
+        $status = trim($_POST['status'] ?? '');
+        $allowed = ['принят', 'в работе', 'на проверке', 'завершен'];
+        if ($orderId <= 0 || !in_array($status, $allowed, true)) {
+            http_response_code(400);
+            echo 'invalid';
+            return;
+        }
+
+        OrderModel::updateStatus($orderId, $status);
+        echo 'ok';
+    }
 }
 ?>

--- a/app/models/OrderModel.php
+++ b/app/models/OrderModel.php
@@ -51,6 +51,14 @@ class OrderModel {
         $stmt->execute();
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
+
+    public static function updateStatus($orderId, $status) {
+        $db = self::getDB();
+        $stmt = $db->prepare("UPDATE orders SET status = :status WHERE order_id = :order_id");
+        $stmt->bindParam(':status', $status);
+        $stmt->bindParam(':order_id', $orderId, PDO::PARAM_INT);
+        $stmt->execute();
+    }
 }
 ?>
 

--- a/public/index.php
+++ b/public/index.php
@@ -26,6 +26,10 @@ switch ($action) {
         require_once __DIR__ . '/../app/controllers/OrderController.php';
         OrderController::create();
         break;
+    case 'update_status':
+        require_once __DIR__ . '/../app/controllers/OrderController.php';
+        OrderController::updateStatus();
+        break;
     default:
         header('Location: ../Program/index.php');
         break;

--- a/public/profile-employee.php
+++ b/public/profile-employee.php
@@ -157,11 +157,11 @@ $displayName = trim($employee['first_name'] . ' ' . $employee['second_name']);
           <td><?php echo htmlspecialchars($order['order_date']); ?></td>
           <td><?php echo htmlspecialchars($order['deadline']); ?></td>
           <td>
-            <select>
-              <option<?php if ($order['status'] === 'принят') echo ' selected'; ?>>Принят</option>
-              <option<?php if ($order['status'] === 'в работе') echo ' selected'; ?>>В работе</option>
-              <option<?php if ($order['status'] === 'на проверке') echo ' selected'; ?>>На проверке</option>
-              <option<?php if ($order['status'] === 'завершен') echo ' selected'; ?>>Завершен</option>
+            <select class="status-select" data-id="<?php echo $order['order_id']; ?>">
+              <option value="принят"<?php if ($order['status'] === 'принят') echo ' selected'; ?>>Принят</option>
+              <option value="в работе"<?php if ($order['status'] === 'в работе') echo ' selected'; ?>>В работе</option>
+              <option value="на проверке"<?php if ($order['status'] === 'на проверке') echo ' selected'; ?>>На проверке</option>
+              <option value="завершен"<?php if ($order['status'] === 'завершен') echo ' selected'; ?>>Завершен</option>
             </select>
           </td>
           <td>
@@ -294,6 +294,21 @@ newOrderBtn.addEventListener('click', () => {
 });
 newOrderOverlay.addEventListener('click', (e) => {
   if (e.target === newOrderOverlay) newOrderOverlay.style.display = 'none';
+});
+
+// изменение статуса заказа
+document.querySelectorAll('.status-select').forEach(sel => {
+  sel.addEventListener('change', () => {
+    const orderId = sel.dataset.id;
+    const status = sel.value;
+    fetch('index.php?action=update_status', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      body: new URLSearchParams({order_id: orderId, status: status})
+    }).then(r => r.text()).then(t => {
+      if (t.trim() !== 'ok') alert('Ошибка обновления статуса');
+    });
+  });
 });
 
 // сообщения об операциях


### PR DESCRIPTION
## Summary
- update orders in DB with new status via OrderModel
- add OrderController endpoint to update status and route in index.php
- submit status changes from employee UI with fetch

## Testing
- `php -l app/models/OrderModel.php`
- `php -l app/controllers/OrderController.php`
- `php -l public/index.php`
- `php -l public/profile-employee.php`

------
https://chatgpt.com/codex/tasks/task_e_6859e0e991ec832f8876ac714b656a2b