### PR TITLE
Prevent order status regression

### DIFF
--- a/app/controllers/OrderController.php
+++ b/app/controllers/OrderController.php
@@ -51,7 +51,12 @@ class OrderController
             return;
         }
 
-        OrderModel::updateStatus($orderId, $status);
+        if (!OrderModel::updateStatus($orderId, $status)) {
+            http_response_code(400);
+            echo 'invalid';
+            return;
+        }
+
         echo 'ok';
     }
 }

--- a/app/models/OrderModel.php
+++ b/app/models/OrderModel.php
@@ -52,12 +52,32 @@ class OrderModel {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    public static function getStatus($orderId) {
+        $db = self::getDB();
+        $stmt = $db->prepare("SELECT status FROM orders WHERE order_id = :order_id");
+        $stmt->bindParam(':order_id', $orderId, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchColumn();
+    }
+
     public static function updateStatus($orderId, $status) {
+        $current = self::getStatus($orderId);
+        if ($current === false) {
+            return false;
+        }
+        $allowed = ['принят', 'в работе', 'на проверке', 'завершен'];
+        $curIndex = array_search($current, $allowed, true);
+        $newIndex = array_search($status, $allowed, true);
+        if ($curIndex === false || $newIndex === false || $newIndex < $curIndex) {
+            return false;
+        }
+
         $db = self::getDB();
         $stmt = $db->prepare("UPDATE orders SET status = :status WHERE order_id = :order_id");
         $stmt->bindParam(':status', $status);
         $stmt->bindParam(':order_id', $orderId, PDO::PARAM_INT);
         $stmt->execute();
+        return true;
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- prevent order status from regressing in `OrderModel`
- return HTTP error if status update is invalid

## Testing
- `php -l app/models/OrderModel.php`
- `php -l app/controllers/OrderController.php`


------
https://chatgpt.com/codex/tasks/task_e_6859e3e4c944832fbd7b4258b85093aa