### PR TITLE
Implement local chat and style updates

### DIFF
--- a/Program/profile-client.html
+++ b/Program/profile-client.html
@@ -156,6 +156,41 @@ notifBtn.addEventListener('click', () => {
 notifOverlay.addEventListener('click', (e) => {
   if (e.target === notifOverlay) notifOverlay.style.display = 'none';
 });
+
+// загрузка сохранённых сообщений из localStorage
+document.querySelectorAll('.order-row').forEach(row => {
+  const id = row.querySelector('td').textContent.trim();
+  row.dataset.orderId = id;
+  const key = 'chat-' + id;
+  const messages = JSON.parse(localStorage.getItem(key) || '[]');
+  const msgBox = row.querySelector('.messages');
+  messages.forEach(m => {
+    const p = document.createElement('p');
+    p.innerHTML = '<strong>' + m.sender + ':</strong> ' + m.text;
+    msgBox.appendChild(p);
+  });
+});
+
+// отправка сообщения
+document.querySelectorAll('.send-message').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const area = btn.closest('.chat-area');
+    const textArea = area.querySelector('textarea');
+    const text = textArea.value.trim();
+    if (!text) return;
+    const row = btn.closest('.order-row');
+    const id = row.dataset.orderId;
+    const p = document.createElement('p');
+    p.innerHTML = '<strong>Вы:</strong> ' + text;
+    area.querySelector('.messages').appendChild(p);
+    const key = 'chat-' + id;
+    const stored = JSON.parse(localStorage.getItem(key) || '[]');
+    stored.push({sender:'Вы', text});
+    localStorage.setItem(key, JSON.stringify(stored));
+    textArea.value = '';
+  });
+});
+
 // ограничение длины сообщений обрабатывается атрибутом maxlength
 </script>
 </body>

--- a/Program/profile-employee.html
+++ b/Program/profile-employee.html
@@ -208,6 +208,40 @@ notifBtn.addEventListener('click', () => {
 notifOverlay.addEventListener('click', (e) => {
   if (e.target === notifOverlay) notifOverlay.style.display = 'none';
 });
+
+// загрузка сообщений из localStorage
+document.querySelectorAll('.order-row').forEach(row => {
+  const id = row.querySelector('td').textContent.trim();
+  row.dataset.orderId = id;
+  const key = 'chat-' + id;
+  const messages = JSON.parse(localStorage.getItem(key) || '[]');
+  const msgBox = row.querySelector('.messages');
+  messages.forEach(m => {
+    const p = document.createElement('p');
+    p.innerHTML = '<strong>' + m.sender + ':</strong> ' + m.text;
+    msgBox.appendChild(p);
+  });
+});
+
+// отправка сообщения
+document.querySelectorAll('.send-message').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const area = btn.closest('.chat-area');
+    const textArea = area.querySelector('textarea');
+    const text = textArea.value.trim();
+    if (!text) return;
+    const row = btn.closest('.order-row');
+    const id = row.dataset.orderId;
+    const p = document.createElement('p');
+    p.innerHTML = '<strong>Вы:</strong> ' + text;
+    area.querySelector('.messages').appendChild(p);
+    const key = 'chat-' + id;
+    const stored = JSON.parse(localStorage.getItem(key) || '[]');
+    stored.push({sender:'Вы', text});
+    localStorage.setItem(key, JSON.stringify(stored));
+    textArea.value = '';
+  });
+});
 </script>
 </body>
 </html>

--- a/Program/style.css
+++ b/Program/style.css
@@ -271,8 +271,16 @@
 .chat-area {
   display: none;
   margin-top: 10px;
-  border: 1px solid #ccc;
+  border: 1px solid #059c42;
+  background: #f7f7f7;
   padding: 10px;
+  border-radius: 6px;
+  max-width: 350px;
+}
+.chat-area .messages {
+  max-height: 150px;
+  overflow-y: auto;
+  margin-bottom: 5px;
 }
 .chat-area textarea {
   width: 100%;

--- a/public/profile-client.php
+++ b/public/profile-client.php
@@ -175,6 +175,40 @@ notifBtn.addEventListener('click', () => {
 notifOverlay.addEventListener('click', (e) => {
   if (e.target === notifOverlay) notifOverlay.style.display = 'none';
 });
+
+// загрузка сообщений из localStorage
+document.querySelectorAll('.order-row').forEach(row => {
+  const id = row.querySelector('td').textContent.trim();
+  row.dataset.orderId = id;
+  const key = 'chat-' + id;
+  const messages = JSON.parse(localStorage.getItem(key) || '[]');
+  const msgBox = row.querySelector('.messages');
+  messages.forEach(m => {
+    const p = document.createElement('p');
+    p.innerHTML = '<strong>' + m.sender + ':</strong> ' + m.text;
+    msgBox.appendChild(p);
+  });
+});
+
+// отправка сообщения
+document.querySelectorAll('.send-message').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const area = btn.closest('.chat-area');
+    const textArea = area.querySelector('textarea');
+    const text = textArea.value.trim();
+    if (!text) return;
+    const row = btn.closest('.order-row');
+    const id = row.dataset.orderId;
+    const p = document.createElement('p');
+    p.innerHTML = '<strong>Вы:</strong> ' + text;
+    area.querySelector('.messages').appendChild(p);
+    const key = 'chat-' + id;
+    const stored = JSON.parse(localStorage.getItem(key) || '[]');
+    stored.push({sender:'Вы', text});
+    localStorage.setItem(key, JSON.stringify(stored));
+    textArea.value = '';
+  });
+});
 // отображение сообщения об успешном запросе
 const params = new URLSearchParams(window.location.search);
 const msgBox = document.getElementById('message');

--- a/public/profile-employee.php
+++ b/public/profile-employee.php
@@ -246,6 +246,40 @@ notifOverlay.addEventListener('click', (e) => {
   if (e.target === notifOverlay) notifOverlay.style.display = 'none';
 });
 
+// загрузка сообщений из localStorage
+document.querySelectorAll('.order-row').forEach(row => {
+  const id = row.querySelector('td').textContent.trim();
+  row.dataset.orderId = id;
+  const key = 'chat-' + id;
+  const messages = JSON.parse(localStorage.getItem(key) || '[]');
+  const msgBox = row.querySelector('.messages');
+  messages.forEach(m => {
+    const p = document.createElement('p');
+    p.innerHTML = '<strong>' + m.sender + ':</strong> ' + m.text;
+    msgBox.appendChild(p);
+  });
+});
+
+// отправка сообщения
+document.querySelectorAll('.send-message').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const area = btn.closest('.chat-area');
+    const textArea = area.querySelector('textarea');
+    const text = textArea.value.trim();
+    if (!text) return;
+    const row = btn.closest('.order-row');
+    const id = row.dataset.orderId;
+    const p = document.createElement('p');
+    p.innerHTML = '<strong>Вы:</strong> ' + text;
+    area.querySelector('.messages').appendChild(p);
+    const key = 'chat-' + id;
+    const stored = JSON.parse(localStorage.getItem(key) || '[]');
+    stored.push({sender:'Вы', text});
+    localStorage.setItem(key, JSON.stringify(stored));
+    textArea.value = '';
+  });
+});
+
 // обработка отклонения заявки
 const declineButtons = document.querySelectorAll('.decline-btn');
 const declineOverlay = document.getElementById('decline-overlay');


### PR DESCRIPTION
## Summary
- implement in-browser chat storage for client and employee profiles
- prettify chat box styling

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6859e5731d2c832fb34e56a170a0f7a6