### PR TITLE
Fix chat UI

### DIFF
--- a/Program/profile-client.html
+++ b/Program/profile-client.html
@@ -112,51 +112,15 @@
   </div>
 </main>
 <script>
-// открыть чат в отдельном окне
+// показать скрытую форму чата в строке заказа
+const myName = document.getElementById('client-name').textContent.trim();
 const toggles = document.querySelectorAll('.chat-toggle');
 toggles.forEach(btn => {
   btn.addEventListener('click', () => {
-    const row = btn.closest('.order-row');
-    const id = row.dataset.orderId || row.querySelector('td').textContent.trim();
-    const otherName = row.querySelector('td:nth-child(2)').textContent.trim();
-    openChatWindow(id, otherName);
+    const area = btn.nextElementSibling;
+    area.style.display = area.style.display === 'block' ? 'none' : 'block';
   });
 });
-
-function openChatWindow(id, otherName) {
-  const chatWin = window.open('', 'chat' + id, 'width=400,height=500');
-  if (!chatWin) return;
-  chatWin.document.write(`<!DOCTYPE html><html lang="ru"><head><meta charset="UTF-8"><title>Чат</title>
-    <style>body{font-family:Arial,sans-serif;margin:10px;} .messages{border:1px solid #ccc;height:350px;overflow-y:auto;padding:5px;margin-bottom:5px;} textarea{width:100%;box-sizing:border-box;}</style>
-  </head><body>
-    <h3>Чат с ${otherName}</h3>
-    <div class="messages"></div>
-    <textarea id="chat-text" maxlength="500" placeholder="Введите сообщение"></textarea>
-    <button id="send-btn">Отправить</button>
-  </body></html>`);
-  chatWin.document.close();
-
-  const msgBox = chatWin.document.querySelector('.messages');
-  const key = 'chat-' + id;
-  const messages = JSON.parse(localStorage.getItem(key) || '[]');
-  messages.forEach(m => {
-    const p = chatWin.document.createElement('p');
-    p.innerHTML = '<strong>' + m.sender + ':</strong> ' + m.text;
-    msgBox.appendChild(p);
-  });
-
-  chatWin.document.getElementById('send-btn').addEventListener('click', () => {
-    const textArea = chatWin.document.getElementById('chat-text');
-    const text = textArea.value.trim();
-    if (!text) return;
-    const p = chatWin.document.createElement('p');
-    p.innerHTML = '<strong>Я:</strong> ' + text;
-    msgBox.appendChild(p);
-    messages.push({sender: 'Я', text});
-    localStorage.setItem(key, JSON.stringify(messages));
-    textArea.value = '';
-  });
-}
 
 // переключение раздела (один раздел)
 const menuButtons = document.querySelectorAll('.profile-menu button');
@@ -218,11 +182,11 @@ document.querySelectorAll('.send-message').forEach(btn => {
     const row = btn.closest('.order-row');
     const id = row.dataset.orderId;
     const p = document.createElement('p');
-    p.innerHTML = '<strong>Я:</strong> ' + text;
+    p.innerHTML = '<strong>' + myName + ':</strong> ' + text;
     area.querySelector('.messages').appendChild(p);
     const key = 'chat-' + id;
     const stored = JSON.parse(localStorage.getItem(key) || '[]');
-    stored.push({sender:'Я', text});
+    stored.push({sender: myName, text});
     localStorage.setItem(key, JSON.stringify(stored));
     textArea.value = '';
   });

--- a/Program/profile-employee.html
+++ b/Program/profile-employee.html
@@ -110,7 +110,7 @@
             <div class="chat-area">
               <div class="messages">
                 <p><strong>Клиент:</strong> Когда будет готов отчет?</p>
-                <p><strong>Я:</strong> Планируем завершить к концу недели.</p>
+                <p><strong>Сотрудник:</strong> Планируем завершить к концу недели.</p>
               </div>
               <textarea maxlength="500" placeholder="Введите сообщение"></textarea>
               <button class="btn send-message">Отправить</button>
@@ -164,51 +164,15 @@
   </div>
 </main>
 <script>
-// открыть чат в отдельном окне
+// показать скрытую форму чата в строке заказа
+const myName = document.getElementById('employee-name').textContent.trim();
 const toggles = document.querySelectorAll('.chat-toggle');
 toggles.forEach(btn => {
   btn.addEventListener('click', () => {
-    const row = btn.closest('.order-row');
-    const id = row.dataset.orderId || row.querySelector('td').textContent.trim();
-    const otherName = row.querySelector('td:nth-child(2)').textContent.trim();
-    openChatWindow(id, otherName);
+    const area = btn.nextElementSibling;
+    area.style.display = area.style.display === 'block' ? 'none' : 'block';
   });
 });
-
-function openChatWindow(id, otherName) {
-  const chatWin = window.open('', 'chat' + id, 'width=400,height=500');
-  if (!chatWin) return;
-  chatWin.document.write(`<!DOCTYPE html><html lang="ru"><head><meta charset="UTF-8"><title>Чат</title>
-    <style>body{font-family:Arial,sans-serif;margin:10px;} .messages{border:1px solid #ccc;height:350px;overflow-y:auto;padding:5px;margin-bottom:5px;} textarea{width:100%;box-sizing:border-box;}</style>
-  </head><body>
-    <h3>Чат с ${otherName}</h3>
-    <div class="messages"></div>
-    <textarea id="chat-text" maxlength="500" placeholder="Введите сообщение"></textarea>
-    <button id="send-btn">Отправить</button>
-  </body></html>`);
-  chatWin.document.close();
-
-  const msgBox = chatWin.document.querySelector('.messages');
-  const key = 'chat-' + id;
-  const messages = JSON.parse(localStorage.getItem(key) || '[]');
-  messages.forEach(m => {
-    const p = chatWin.document.createElement('p');
-    p.innerHTML = '<strong>' + m.sender + ':</strong> ' + m.text;
-    msgBox.appendChild(p);
-  });
-
-  chatWin.document.getElementById('send-btn').addEventListener('click', () => {
-    const textArea = chatWin.document.getElementById('chat-text');
-    const text = textArea.value.trim();
-    if (!text) return;
-    const p = chatWin.document.createElement('p');
-    p.innerHTML = '<strong>Я:</strong> ' + text;
-    msgBox.appendChild(p);
-    messages.push({sender: 'Я', text});
-    localStorage.setItem(key, JSON.stringify(messages));
-    textArea.value = '';
-  });
-}
 // ограничение размера файла
 const fileInputs = document.querySelectorAll('input[type="file"]');
 fileInputs.forEach(inp => {
@@ -270,11 +234,11 @@ document.querySelectorAll('.send-message').forEach(btn => {
     const row = btn.closest('.order-row');
     const id = row.dataset.orderId;
    const p = document.createElement('p');
-    p.innerHTML = '<strong>Я:</strong> ' + text;
+    p.innerHTML = '<strong>' + myName + ':</strong> ' + text;
     area.querySelector('.messages').appendChild(p);
     const key = 'chat-' + id;
     const stored = JSON.parse(localStorage.getItem(key) || '[]');
-    stored.push({sender:'Я', text});
+    stored.push({sender: myName, text});
     localStorage.setItem(key, JSON.stringify(stored));
     textArea.value = '';
   });


### PR DESCRIPTION
## Summary
- display chat areas inline instead of opening new windows
- show sender names based on current user

## Testing
- `php -l public/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ed938afc832f86471b05bb8d9244