### PR TITLE
Enhance chat interaction with modal overlay

### DIFF
--- a/Program/profile-client.html
+++ b/Program/profile-client.html
@@ -110,16 +110,34 @@
       </ul>
     </div>
   </div>
+  <div id="chat-overlay" class="overlay">
+    <div id="chat-modal" class="modal-form"></div>
+  </div>
 </main>
 <script>
-// показать скрытую форму чата в строке заказа
+// модальное окно чата
 const myName = document.getElementById('client-name').textContent.trim();
 const toggles = document.querySelectorAll('.chat-toggle');
+const chatOverlay = document.getElementById('chat-overlay');
+const chatModal = document.getElementById('chat-modal');
+let activeChatArea = null;
+let activeChatParent = null;
 toggles.forEach(btn => {
   btn.addEventListener('click', () => {
-    const area = btn.nextElementSibling;
-    area.style.display = area.style.display === 'block' ? 'none' : 'block';
+    activeChatArea = btn.nextElementSibling;
+    activeChatParent = btn.parentNode;
+    activeChatArea.style.display = 'block';
+    chatModal.appendChild(activeChatArea);
+    chatOverlay.style.display = 'flex';
   });
+});
+
+chatOverlay.addEventListener('click', (e) => {
+  if (e.target === chatOverlay && activeChatArea) {
+    activeChatArea.style.display = 'none';
+    activeChatParent.appendChild(activeChatArea);
+    chatOverlay.style.display = 'none';
+  }
 });
 
 // переключение раздела (один раздел)
@@ -162,6 +180,7 @@ notifOverlay.addEventListener('click', (e) => {
 document.querySelectorAll('.order-row').forEach(row => {
   const id = row.querySelector('td').textContent.trim();
   row.dataset.orderId = id;
+  row.querySelector('.chat-area').dataset.orderId = id;
   const key = 'chat-' + id;
   const messages = JSON.parse(localStorage.getItem(key) || '[]');
   const msgBox = row.querySelector('.messages');
@@ -179,8 +198,7 @@ document.querySelectorAll('.send-message').forEach(btn => {
     const textArea = area.querySelector('textarea');
     const text = textArea.value.trim();
     if (!text) return;
-    const row = btn.closest('.order-row');
-    const id = row.dataset.orderId;
+    const id = area.dataset.orderId;
     const p = document.createElement('p');
     p.innerHTML = '<strong>' + myName + ':</strong> ' + text;
     area.querySelector('.messages').appendChild(p);

--- a/Program/profile-employee.html
+++ b/Program/profile-employee.html
@@ -162,16 +162,34 @@
       </ul>
     </div>
   </div>
+  <div id="chat-overlay" class="overlay">
+    <div id="chat-modal" class="modal-form"></div>
+  </div>
 </main>
 <script>
-// показать скрытую форму чата в строке заказа
+// модальное окно чата
 const myName = document.getElementById('employee-name').textContent.trim();
 const toggles = document.querySelectorAll('.chat-toggle');
+const chatOverlay = document.getElementById('chat-overlay');
+const chatModal = document.getElementById('chat-modal');
+let activeChatArea = null;
+let activeChatParent = null;
 toggles.forEach(btn => {
   btn.addEventListener('click', () => {
-    const area = btn.nextElementSibling;
-    area.style.display = area.style.display === 'block' ? 'none' : 'block';
+    activeChatArea = btn.nextElementSibling;
+    activeChatParent = btn.parentNode;
+    activeChatArea.style.display = 'block';
+    chatModal.appendChild(activeChatArea);
+    chatOverlay.style.display = 'flex';
   });
+});
+
+chatOverlay.addEventListener('click', (e) => {
+  if (e.target === chatOverlay && activeChatArea) {
+    activeChatArea.style.display = 'none';
+    activeChatParent.appendChild(activeChatArea);
+    chatOverlay.style.display = 'none';
+  }
 });
 // ограничение размера файла
 const fileInputs = document.querySelectorAll('input[type="file"]');
@@ -214,6 +232,7 @@ notifOverlay.addEventListener('click', (e) => {
 document.querySelectorAll('.order-row').forEach(row => {
   const id = row.querySelector('td').textContent.trim();
   row.dataset.orderId = id;
+  row.querySelector('.chat-area').dataset.orderId = id;
   const key = 'chat-' + id;
   const messages = JSON.parse(localStorage.getItem(key) || '[]');
   const msgBox = row.querySelector('.messages');
@@ -231,9 +250,8 @@ document.querySelectorAll('.send-message').forEach(btn => {
     const textArea = area.querySelector('textarea');
     const text = textArea.value.trim();
     if (!text) return;
-    const row = btn.closest('.order-row');
-    const id = row.dataset.orderId;
-   const p = document.createElement('p');
+    const id = area.dataset.orderId;
+    const p = document.createElement('p');
     p.innerHTML = '<strong>' + myName + ':</strong> ' + text;
     area.querySelector('.messages').appendChild(p);
     const key = 'chat-' + id;

--- a/Program/style.css
+++ b/Program/style.css
@@ -328,6 +328,10 @@
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
 }
 
+.chat-modal {
+  max-width: 400px;
+}
+
 #employee-name{
   color: #059c42;
 }

--- a/public/profile-client.php
+++ b/public/profile-client.php
@@ -129,15 +129,33 @@ $displayName = $client['name'] ?: $client['company_name'];
       </ul>
     </div>
   </div>
+  <div id="chat-overlay" class="overlay">
+    <div id="chat-modal" class="modal-form"></div>
+  </div>
 </main>
 <script>
-// показать скрытую форму чата в строке заказа
+// модальное окно чата
 const toggles = document.querySelectorAll('.chat-toggle');
+const chatOverlay = document.getElementById('chat-overlay');
+const chatModal = document.getElementById('chat-modal');
+let activeChatArea = null;
+let activeChatParent = null;
 toggles.forEach(btn => {
   btn.addEventListener('click', () => {
-    const area = btn.nextElementSibling;
-    area.style.display = area.style.display === 'block' ? 'none' : 'block';
+    activeChatArea = btn.nextElementSibling;
+    activeChatParent = btn.parentNode;
+    activeChatArea.style.display = 'block';
+    chatModal.appendChild(activeChatArea);
+    chatOverlay.style.display = 'flex';
   });
+});
+
+chatOverlay.addEventListener('click', (e) => {
+  if (e.target === chatOverlay && activeChatArea) {
+    activeChatArea.style.display = 'none';
+    activeChatParent.appendChild(activeChatArea);
+    chatOverlay.style.display = 'none';
+  }
 });
 
 // переключение раздела (один раздел)
@@ -180,6 +198,7 @@ notifOverlay.addEventListener('click', (e) => {
 document.querySelectorAll('.order-row').forEach(row => {
   const id = row.querySelector('td').textContent.trim();
   row.dataset.orderId = id;
+  row.querySelector('.chat-area').dataset.orderId = id;
   const key = 'chat-' + id;
   const messages = JSON.parse(localStorage.getItem(key) || '[]');
   const msgBox = row.querySelector('.messages');
@@ -197,8 +216,7 @@ document.querySelectorAll('.send-message').forEach(btn => {
     const textArea = area.querySelector('textarea');
     const text = textArea.value.trim();
     if (!text) return;
-    const row = btn.closest('.order-row');
-    const id = row.dataset.orderId;
+    const id = area.dataset.orderId;
     const p = document.createElement('p');
     p.innerHTML = '<strong>Я:</strong> ' + text;
     area.querySelector('.messages').appendChild(p);

--- a/public/profile-employee.php
+++ b/public/profile-employee.php
@@ -199,15 +199,33 @@ $displayName = trim($employee['first_name'] . ' ' . $employee['second_name']);
       </ul>
     </div>
   </div>
+  <div id="chat-overlay" class="overlay">
+    <div id="chat-modal" class="modal-form"></div>
+  </div>
 </main>
 <script>
-// показать скрытую форму чата в строке заказа
+// модальное окно чата
 const toggles = document.querySelectorAll('.chat-toggle');
+const chatOverlay = document.getElementById('chat-overlay');
+const chatModal = document.getElementById('chat-modal');
+let activeChatArea = null;
+let activeChatParent = null;
 toggles.forEach(btn => {
   btn.addEventListener('click', () => {
-    const area = btn.nextElementSibling;
-    area.style.display = area.style.display === 'block' ? 'none' : 'block';
+    activeChatArea = btn.nextElementSibling;
+    activeChatParent = btn.parentNode;
+    activeChatArea.style.display = 'block';
+    chatModal.appendChild(activeChatArea);
+    chatOverlay.style.display = 'flex';
   });
+});
+
+chatOverlay.addEventListener('click', (e) => {
+  if (e.target === chatOverlay && activeChatArea) {
+    activeChatArea.style.display = 'none';
+    activeChatParent.appendChild(activeChatArea);
+    chatOverlay.style.display = 'none';
+  }
 });
 // ограничение размера файла
 const fileInputs = document.querySelectorAll('input[type="file"]');
@@ -250,6 +268,7 @@ notifOverlay.addEventListener('click', (e) => {
 document.querySelectorAll('.order-row').forEach(row => {
   const id = row.querySelector('td').textContent.trim();
   row.dataset.orderId = id;
+  row.querySelector('.chat-area').dataset.orderId = id;
   const key = 'chat-' + id;
   const messages = JSON.parse(localStorage.getItem(key) || '[]');
   const msgBox = row.querySelector('.messages');
@@ -267,8 +286,7 @@ document.querySelectorAll('.send-message').forEach(btn => {
     const textArea = area.querySelector('textarea');
     const text = textArea.value.trim();
     if (!text) return;
-    const row = btn.closest('.order-row');
-    const id = row.dataset.orderId;
+    const id = area.dataset.orderId;
     const p = document.createElement('p');
     p.innerHTML = '<strong>Я:</strong> ' + text;
     area.querySelector('.messages').appendChild(p);


### PR DESCRIPTION
## Summary
- update profile pages to show chat in a centered modal overlay
- move chat DOM elements into overlay when opened
- keep chat history per order with data attributes
- style modal overlay for chat

## Testing
- `php -l public/profile-client.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f0a7dad4832fbe32d9475ab30445