### PR TITLE
Fix report upload feature

### DIFF
--- a/app/controllers/OrderController.php
+++ b/app/controllers/OrderController.php
@@ -59,5 +59,56 @@ class OrderController
 
         echo 'ok';
     }
+
+    public static function addReport()
+    {
+        session_start();
+        if (!isset($_SESSION['emp_id'])) {
+            header('Location: ../Program/auth.html');
+            exit;
+        }
+
+        $orderId = intval($_POST['order_id'] ?? 0);
+        if ($orderId <= 0 || !isset($_FILES['report_file'])) {
+            header('Location: profile-employee.php?error=invalid');
+            exit;
+        }
+
+        $file = $_FILES['report_file'];
+        if ($file['error'] !== UPLOAD_ERR_OK) {
+            header('Location: profile-employee.php?error=upload');
+            exit;
+        }
+        if ($file['size'] > 20 * 1024 * 1024) {
+            header('Location: profile-employee.php?error=size');
+            exit;
+        }
+        $finfo = new finfo(FILEINFO_MIME_TYPE);
+        $mime = $finfo->file($file['tmp_name']);
+        if ($mime !== 'application/pdf') {
+            header('Location: profile-employee.php?error=type');
+            exit;
+        }
+
+        $dir = __DIR__ . '/../../uploads';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        $filename = uniqid('report_', true) . '.pdf';
+        $dest = $dir . '/' . $filename;
+        if (!move_uploaded_file($file['tmp_name'], $dest)) {
+            header('Location: profile-employee.php?error=save');
+            exit;
+        }
+
+        require_once __DIR__ . '/../models/ReportModel.php';
+        $path = '../uploads/' . $filename;
+        ReportModel::addReport($orderId, $_SESSION['emp_id'], $path);
+
+        OrderModel::updateStatus($orderId, 'на проверке');
+
+        header('Location: profile-employee.php?success=uploaded');
+        exit;
+    }
 }
 ?>

--- a/app/models/ReportModel.php
+++ b/app/models/ReportModel.php
@@ -1,0 +1,30 @@
+<?php
+class ReportModel {
+    protected static function getDB() {
+        static $db = null;
+        if ($db === null) {
+            $dsn = getenv('DB_DSN') ?: 'pgsql:host=localhost;port=5432;dbname=NatureSecur';
+            $user = getenv('DB_USER') ?: 'postgres';
+            $pass = getenv('DB_PASS') ?: 'ristal2222';
+            $db = new PDO($dsn, $user, $pass);
+            $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        }
+        return $db;
+    }
+
+    public static function addReport($orderId, $empId, $filePath) {
+        $db = self::getDB();
+        $stmt = $db->prepare('SELECT COALESCE(MAX(version),0) + 1 FROM reports WHERE order_id = :order_id');
+        $stmt->bindParam(':order_id', $orderId, PDO::PARAM_INT);
+        $stmt->execute();
+        $version = $stmt->fetchColumn();
+
+        $stmt = $db->prepare('INSERT INTO reports (order_id, emp_id, file_path, version) VALUES (:order_id, :emp_id, :file_path, :version)');
+        $stmt->bindParam(':order_id', $orderId, PDO::PARAM_INT);
+        $stmt->bindParam(':emp_id', $empId, PDO::PARAM_INT);
+        $stmt->bindParam(':file_path', $filePath);
+        $stmt->bindParam(':version', $version, PDO::PARAM_INT);
+        $stmt->execute();
+    }
+}
+?>

--- a/public/index.php
+++ b/public/index.php
@@ -30,6 +30,10 @@ switch ($action) {
         require_once __DIR__ . '/../app/controllers/OrderController.php';
         OrderController::updateStatus();
         break;
+    case 'add_report':
+        require_once __DIR__ . '/../app/controllers/OrderController.php';
+        OrderController::addReport();
+        break;
     default:
         header('Location: ../Program/index.php');
         break;

--- a/public/profile-employee.php
+++ b/public/profile-employee.php
@@ -165,10 +165,14 @@ $displayName = trim($employee['first_name'] . ' ' . $employee['second_name']);
             </select>
           </td>
           <td>
-            <label class="file-label">
-              Прикрепить отчет
-              <input type="file" accept="application/pdf">
-            </label>
+            <form class="upload-form" action="index.php?action=add_report" method="post" enctype="multipart/form-data" style="display:inline-block;">
+              <input type="hidden" name="order_id" value="<?php echo $order['order_id']; ?>">
+              <label class="file-label">
+                Прикрепить отчет
+                <input type="file" name="report_file" accept="application/pdf" required>
+              </label>
+              <button type="submit" class="btn">Добавить отчёт</button>
+            </form>
             <button class="btn chat-toggle">Чат</button>
             <div class="chat-area" style="display:none;">
               <div class="messages"></div>
@@ -228,7 +232,7 @@ chatOverlay.addEventListener('click', (e) => {
   }
 });
 // ограничение размера файла
-const fileInputs = document.querySelectorAll('input[type="file"]');
+const fileInputs = document.querySelectorAll('.upload-form input[type="file"]');
 fileInputs.forEach(inp => {
   inp.addEventListener('change', (e) => {
     const file = e.target.files[0];


### PR DESCRIPTION
## Summary
- add `ReportModel` for report DB operations
- allow employees to upload reports via `OrderController::addReport`
- route uploads through `index.php` with `action=add_report`
- update employee profile page with report upload form
- keep uploads in repo via `.gitkeep`

## Testing
- `php` not installed, so no automated tests run

------
https://chatgpt.com/codex/tasks/task_e_6859f9346b20832fb8a605d38912151a