### PR TITLE
Fix admin panel menu and client creation

### DIFF
--- a/Program/style.css
+++ b/Program/style.css
@@ -362,3 +362,16 @@
   width: 100%;
   padding: 2px;
 }
+
+.client-form {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.client-form input {
+  padding: 6px;
+}
+.profile-heading {
+  margin-bottom: 20px;
+}

--- a/app/controllers/AdminController.php
+++ b/app/controllers/AdminController.php
@@ -14,9 +14,9 @@ class AdminController
         $login = trim($_POST['login'] ?? '');
         $email = trim($_POST['email'] ?? '');
         $phone = trim($_POST['phone'] ?? '');
-        $role = trim($_POST['role'] ?? '');
+        $role = 'сотрудник';
         $password = $_POST['password'] ?? '';
-        if ($first === '' || $second === '' || $login === '' || $email === '' || $password === '' || ($role !== 'сотрудник' && $role !== 'администратор')) {
+        if ($first === '' || $second === '' || $login === '' || $email === '' || $password === '') {
             header('Location: profile-admin.php?error=invalid');
             exit;
         }
@@ -73,6 +73,26 @@ class AdminController
         }
         OrderModel::updateOrder($id, $clientId, $empId, $orderType, $deadline, $status);
         header('Location: profile-admin.php?success=order_updated');
+        exit;
+    }
+
+    public static function addClient()
+    {
+        session_start();
+        if (!self::checkRole()) return;
+
+        $name = trim($_POST['name'] ?? '');
+        $company = trim($_POST['company_name'] ?? '');
+        $email = trim($_POST['email'] ?? '');
+        $phone = trim($_POST['phone'] ?? '');
+        $password = $_POST['password'] ?? '';
+        if ($email === '' || $password === '') {
+            header('Location: profile-admin.php?error=invalid');
+            exit;
+        }
+        require_once __DIR__ . '/../models/ClientModel.php';
+        ClientModel::createClient($name, $company, $email, $phone, $password);
+        header('Location: profile-admin.php?success=client_added');
         exit;
     }
 

--- a/public/index.php
+++ b/public/index.php
@@ -34,6 +34,10 @@ switch ($action) {
         require_once __DIR__ . '/../app/controllers/OrderController.php';
         OrderController::addReport();
         break;
+    case 'add_client':
+        require_once __DIR__ . '/../app/controllers/AdminController.php';
+        AdminController::addClient();
+        break;
     case 'add_employee':
         require_once __DIR__ . '/../app/controllers/AdminController.php';
         AdminController::addEmployee();

--- a/public/profile-admin.php
+++ b/public/profile-admin.php
@@ -53,12 +53,12 @@ $displayName = trim($employee['first_name'] . ' ' . $employee['second_name']);
     <h1>Личный кабинет администратора <br> Добро пожаловать, <span id="employee-name"><?php echo htmlspecialchars($displayName); ?></span></h1>
     <button id="notifications-btn" class="notify-btn"><img src="../Program/bell.svg" alt="Уведомления"></button>
   </div>
-  <nav class="profile-menu">
+  <nav id="main-menu" class="profile-menu">
     <button data-target="personal" class="profile-highlight active">Мой профиль</button>
     <button data-target="panel">Админ панель</button>
   </nav>
   <section class="profile-section" id="panel" style="display:none;">
-    <nav class="profile-menu">
+    <nav id="admin-menu" class="profile-menu">
       <button data-target="users" class="profile-highlight active">Пользователи</button>
       <button data-target="admin-orders">Заказы</button>
       <button data-target="changes">Журнал изменений</button>
@@ -90,10 +90,7 @@ $displayName = trim($employee['first_name'] . ' ' . $employee['second_name']);
               <td><input name="phone"></td>
               <td><input name="login" required></td>
               <td>
-                <select name="role">
-                  <option value="сотрудник">Сотрудник</option>
-                  <option value="администратор">Администратор</option>
-                </select>
+                Сотрудник<input type="hidden" name="role" value="сотрудник">
               </td>
               <td><input name="password" type="password" required></td>
               <td><button class="btn" type="submit">Добавить</button></td>
@@ -124,6 +121,15 @@ $displayName = trim($employee['first_name'] . ' ' . $employee['second_name']);
           <?php endforeach; ?>
         </tbody>
       </table>
+      <h3>Новый клиент</h3>
+      <form class="client-form" action="index.php?action=add_client" method="post">
+        <input name="name" placeholder="ФИО">
+        <input name="company_name" placeholder="Компания">
+        <input name="email" placeholder="Email" required>
+        <input name="phone" placeholder="Телефон">
+        <input name="password" type="password" placeholder="Пароль" required>
+        <button class="btn" type="submit">Добавить</button>
+      </form>
       </div>
     </section>
     <section class="profile-section" id="admin-orders" style="display:none;">
@@ -230,7 +236,7 @@ $displayName = trim($employee['first_name'] . ' ' . $employee['second_name']);
 </main>
 <script>
 // переключение основного меню
-const mainButtons = document.querySelectorAll('nav.profile-menu > button');
+const mainButtons = document.querySelectorAll('#main-menu > button');
 const mainSections = document.querySelectorAll('main > .profile-section');
 mainButtons.forEach(btn => {
   btn.addEventListener('click', () => {
@@ -243,10 +249,10 @@ mainButtons.forEach(btn => {
   });
 });
 // показать первый раздел
-document.querySelector('nav.profile-menu button.active').click();
+document.querySelector('#main-menu button.active').click();
 
 // меню админ-панели
-const adminButtons = document.querySelectorAll('#panel nav.profile-menu button');
+const adminButtons = document.querySelectorAll('#admin-menu button');
 const adminSections = document.querySelectorAll('#panel .profile-section');
 adminButtons.forEach(btn => {
   btn.addEventListener('click', () => {
@@ -258,7 +264,7 @@ adminButtons.forEach(btn => {
     });
   });
 });
-document.querySelector('#panel nav.profile-menu button.active').click();
+document.querySelector('#admin-menu button.active').click();
 
 const notifBtn = document.getElementById('notifications-btn');
 const notifOverlay = document.getElementById('notifications-overlay');


### PR DESCRIPTION
## Summary
- fix disappearing sections in admin panel by using separate menu IDs
- disable creation of administrator accounts
- allow creating client accounts
- add spacing via CSS

## Testing
- `php -l public/profile-admin.php`
- `php -l app/controllers/AdminController.php`
- `php -l public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_685a0041e0f0832fa9f6728f7c99f0b7